### PR TITLE
fix: add openssl

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -35,7 +35,8 @@ RUN apk add --update --no-cache --repository=https://dl-cdn.alpinelinux.org/alpi
     xmlsec-dev \
     xmlsec \
     uv \
-    pnpm
+    pnpm \
+    openssl
 
 RUN uv venv ${VIRTUAL_ENV}
 RUN source ${VIRTUAL_ENV}/bin/activate


### PR DESCRIPTION
- alpine:edge somehow does not *always* have openssl installed 
- add it to the installed packages list until a stable alpine version with python3.13